### PR TITLE
correct json format of config file

### DIFF
--- a/src/usage/cli.md
+++ b/src/usage/cli.md
@@ -22,7 +22,7 @@ Sensitive values, such as API tokens or passwords, should be handled with more c
     "confluenceBaseUrl": "https://markdown-confluence.atlassian.net",
     "confluenceParentId": "524353",
     "atlassianUserName": "andrew.mcclenaghan@gmail.com",
-    "folderToPublish": ".",
+    "folderToPublish": "."
   }
 ```
 


### PR DESCRIPTION
I ran into this because I copied the content from here and I was wondering why the base url was not recognized. The comma made the json corrupt and the config was not read.