### PR TITLE
Update docs to reference V5 action instead of V1

### DIFF
--- a/src/usage/github-actions.md
+++ b/src/usage/github-actions.md
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Publish Markdown to Confluence
-        uses: markdown-confluence/publish@v1
+        uses: markdown-confluence/publish-action@v5
         with:
           confluenceBaseUrl: https://your-confluence-instance-url
           confluenceParentId: 123456
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Publish Markdown to Confluence
-        uses: markdown-confluence/publish@v1
+        uses: markdown-confluence/publish-action@v5
         with:
           configFile: .markdown-confluence.json
           atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
@@ -164,7 +164,7 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Publish Markdown to Confluence
-        uses: markdown-confluence/publish@v1
+        uses: markdown-confluence/publish-action@v5
         with:
           confluenceBaseUrl: https://your-confluence-instance-url
           confluenceParentId: 123456


### PR DESCRIPTION
Update docs to reference the V5 action, resolving the `Error: Unable to resolve action markdown-confluence/publish, repository not found` error encountered when users try to run the action.